### PR TITLE
Fix transformNumber typo and cleanup animation listener

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ const view = {
     return `<div data-index="${index}" class="card back"></div>`
   },
   getCardContent(index) {
-    const number = this.transformNuMber((index % 13) + 1)
+    const number = this.transformNumber((index % 13) + 1)
     const symbol = Symbols[Math.floor(index / 13)]
     return `
       <p>${number}</p>
@@ -24,7 +24,7 @@ const view = {
       <p>${number}</p>
       `
   },
-  transformNuMber (number) {
+  transformNumber (number) {
     switch (number) {
       case 1:
         return 'A'
@@ -69,8 +69,13 @@ const view = {
   appendWrongAnimation(...cards) {
     cards.map(card => {
       card.classList.add('wrong')
-      card.addEventListener('animationend', event =>
-      event.target.classList.remove('wrong'), { once: true})
+      card.addEventListener(
+        'animationend',
+        event => {
+          event.target.classList.remove('wrong')
+        },
+        { once: true }
+      )
     })
   },
   showGameFinished () {


### PR DESCRIPTION
## Summary
- rename `transformNuMber` to `transformNumber`
- clarify wrong animation event listener logic

## Testing
- `node main.js` *(fails: document is not defined, expected for DOM code)*

------
https://chatgpt.com/codex/tasks/task_e_687e6a314198832692ccc6845d958a5c